### PR TITLE
Wrap proposal text at 160 chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,69 +1,119 @@
 #Bikeshed Proposal
 
 ##Abstract
-The purpose of the Bikeshed project is to determine the technical direction, logo and name of the project (however, this is still under discussion).  Bikeshedding is a key requirement for most open-source development projects, and software projects in general, and we think it’s important to build something that satisfies these needs.
+
+The purpose of the Bikeshed project is to determine the technical direction, logo and name of the project (however, this is still under discussion).
+Bikeshedding is a key requirement for most open-source development projects, and software projects in general, and we think it’s important to build something
+that satisfies these needs.
 
 ##Proposal
-We propose to contribute Bikeshed and associated artifacts (whatever they turn out to be) to the Apache Software Foundation with the intent of forming a productive, bureaucratic and open community around Bikeshed through continued and exhaustive discussion.
+
+We propose to contribute Bikeshed and associated artifacts (whatever they turn out to be) to the Apache Software Foundation with the intent of forming a
+productive, bureaucratic and open community around Bikeshed through continued and exhaustive discussion.
 
 ##Background
-Since the beginning of software design, there has been a need for individuals to offer strong opinions on key features related to the project. These discussions revolve around naming objects, and logo designs, although the Bikeshed project hopes to grow to encompass naming modules, website colors, error messages and renaming objects. Bikeshed exists to provide structure and rigor around these crucially trivial discussions, whether they be in-person, in a JIRA or on the mailing list. Typically, as projects grow in complexity, the amount of meaningful feedback on larger features is minimal, however everyone seems to have an opinion on relatively meaningless design decisions. Little or no knowledge of systems is required.
+
+Since the beginning of software design, there has been a need for individuals to offer strong opinions on key features related to the project. These discussions
+revolve around naming objects, and logo designs, although the Bikeshed project hopes to grow to encompass naming modules, website colors, error messages and
+renaming objects. Bikeshed exists to provide structure and rigor around these crucially trivial discussions, whether they be in-person, in a JIRA or on the
+mailing list. Typically, as projects grow in complexity, the amount of meaningful feedback on larger features is minimal, however everyone seems to have an
+opinion on relatively meaningless design decisions. Little or no knowledge of systems is required.
 
 ##Rationale
-Despite the abundance of tools for group collaboration already in adoption, the Bikeshed team has very strong opinions that will provide an improvement in all software projects, and allow for Bikeshedding at a massive scale. Extended discussion, thought, and scrutiny, paid to details which have small impact on the project as a whole, is something that all engineers can understand. The timing is right to introduce this framework, or template, or whatever it turns out to be, to the community at large. We believe the ASF is the correct venue to foster the continued operation of this project, in spite of any internal Bikeshed stagnation. The current core developers are very excited to add an official commit bit.
+
+Despite the abundance of tools for group collaboration already in adoption, the Bikeshed team has very strong opinions that will provide an improvement in all
+software projects, and allow for Bikeshedding at a massive scale. Extended discussion, thought, and scrutiny, paid to details which have small impact on the
+project as a whole, is something that all engineers can understand. The timing is right to introduce this framework, or template, or whatever it turns out to
+be, to the community at large. We believe the ASF is the correct venue to foster the continued operation of this project, in spite of any internal Bikeshed
+stagnation. The current core developers are very excited to add an official commit bit.
 
 ##Initial Goals
+
 Our initial goals are as follows:
+
 * Discuss color palettes for the initial website.
 * Determine if Bikeshed is actually the name of the project.
 * Discuss web frameworks for the site.
 * Refine the voting.
-* Talk more about the name of the project
+* Talk more about the name of the project.
 * Transfer source code, documentation and associated artifacts to the ASF.
-* Draw a picture of the logo in black and white, apply a photoshop filter from early 2000
+* Draw a picture of the logo in black and white, apply a photoshop filter from early 2000.
 * Grow the user and developer communities.
 * Design the initial website, including color and layout.
-* Current Status
 
-Bikeshed is currently under discussion for the correct licensing model, though we are close to deciding on Apache.  There are numerous logo sources available in MS Paint on the founders laptops. All code reviews must be done on public instances of the Gerrit, Crucible, and GitLab (Note: There is an ongoing discussion about changing the review process and tools). The reviews must then be signed in triplicate with wet ink from all committers before a discussion to include the patch upstream can begin. Before a patch is committed, it must pass a suite of pre-commit software and grammar tests.  These tests are currently being voted on where to be hosted. One of our initial goals will be to work with the ASF Infrastructure team to find a way to run these tests in an acceptable way on publicly accessible machines.
+##Current Status
+
+Bikeshed is currently under discussion for the correct licensing model, though we are close to deciding on Apache.  There are numerous logo sources available in
+MS Paint on the founders laptops. All code reviews must be done on public instances of the Gerrit, Crucible, and GitLab (Note: There is an ongoing discussion
+about changing the review process and tools). The reviews must then be signed in triplicate with wet ink from all committers before a discussion to include the
+patch upstream can begin. Before a patch is committed, it must pass a suite of pre-commit software and grammar tests.  These tests are currently being voted on
+where to be hosted. One of our initial goals will be to work with the ASF Infrastructure team to find a way to run these tests in an acceptable way on publicly
+accessible machines.
 
 ##Meritocracy
-We understand the central importance of meritocracy to the Apache Way. We will work to establish a welcoming, fair and meritocratic community, in part by expanding the set of committers on the project. Although Bikeshed’s committer list will initially be dominated by members of the Apache Community and the members of the Barista community, we look forward to growing a rich user and developer community.
+
+We understand the central importance of meritocracy to the Apache Way. We will work to establish a welcoming, fair and meritocratic community, in part by
+expanding the set of committers on the project. Although Bikeshed’s committer list will initially be dominated by members of the Apache Community and the
+members of the Barista community, we look forward to growing a rich user and developer community.
 
 ##Community
-Bikeshed will ultimately have strong community. We will have an email alias of either bikeshed-dev or dev-bikeshed (under discussion). We wish to attract more developers to the project, and we believe that the ASF’s open and meritocratic philosophy will help us with this. We note the success of other, similar projects already part of the ASF.
+
+Bikeshed will ultimately have strong community. We will have an email alias of either bikeshed-dev or dev-bikeshed (under discussion). We wish to attract more
+developers to the project, and we believe that the ASF’s open and meritocratic philosophy will help us with this. We note the success of other, similar projects
+already part of the ASF.
 
 ##Core Developers
+
 Bikeshed developers come from all walks of life.
 
 ##Alignment
+
 Bikeshedding is related to all software projects:
 
-For a non-inclusive list of those related under the Apache umbrella see the following:
-https://projects.apache.org/projects.html
+For a non-inclusive list of those related under the Apache umbrella see the following: https://projects.apache.org/projects.html
 
 ##Known Risks
 
 ##Inexperience with Open Source
-Although all committers on the initial list have significant experience with at least one open-source project, fewer have much experience with ASF-based software projects as contributors and community members. However, with the guidance of our mentors, committers who do have ASF experience, and time to learn during Incubation, we are confident that the project can be run in accordance with Apache principles on an ongoing basis.
+
+Although all committers on the initial list have significant experience with at least one open-source project, fewer have much experience with ASF-based
+software projects as contributors and community members. However, with the guidance of our mentors, committers who do have ASF experience, and time to learn
+during Incubation, we are confident that the project can be run in accordance with Apache principles on an ongoing basis.
 
 ##Continued Discussion About the Spelling of “Bikeshed”
-Although many (but not all) of the committers have agreed that Bikeshed is the appropriate name for the project there is still an ongoing and lively discussion as to the exact spelling of Bikeshed.  Approximately one third of current project members believe “BikeShed” is the ideal spelling however there are factions that feel otherwise.  bikeShed, bikeSHED, and even bicycleshed have all been suggested as the official project name.  All of these suggestions must be carefully considered to avoid creating a schism within the project.  In addition to the spelling there have been passionate arguments about whether Times New Roman, Calibre, or Courier New should be official font of the logo.
+
+Although many (but not all) of the committers have agreed that Bikeshed is the appropriate name for the project there is still an ongoing and lively discussion
+as to the exact spelling of Bikeshed.  Approximately one third of current project members believe “BikeShed” is the ideal spelling however there are factions
+that feel otherwise.  bikeShed, bikeSHED, and even bicycleshed have all been suggested as the official project name.  All of these suggestions must be carefully
+considered to avoid creating a schism within the project.  In addition to the spelling there have been passionate arguments about whether Times New Roman,
+Calibre, or Courier New should be official font of the logo.
 
 ##Ongoing Debate About Documentation Font
-There have been many spirited discussions amongst the committers about the proper font to be used documentation. These discussions were the direct result of the still unresolved discussions about the font to be used for the project logo (see above). The discussion of this topic has become so contentious that one faction has threatened to fork BikeShed (or bikeShed or bikeSHED) and create Apache YakShave in response to this impasse.    
+
+There have been many spirited discussions amongst the committers about the proper font to be used documentation. These discussions were the direct result of the
+still unresolved discussions about the font to be used for the project logo (see above). The discussion of this topic has become so contentious that one faction
+has threatened to fork BikeShed (or bikeShed or bikeSHED) and create Apache YakShave in response to this impasse.
 
 ##Homogeneous Developers
-The initial committers are mostly employees of Cloudera.
-The project has received some contributions from developers outside of Cloudera, from individuals belonging to organizations such as Starbucks and Initech Software, from the fun-employed, and from psychology and philosophy students using Bikeshed to advance their understanding of due process on the internet. The project attracted an active user community as well. We hope to continue to encourage lack luster contributions from these developers and community members and grow them into committers after they have had time to continue their contributions.
+
+The initial committers are mostly employees of Cloudera. The project has received some contributions from developers outside of Cloudera, from individuals
+belonging to organizations such as Starbucks and Initech Software, from the fun-employed, and from psychology and philosophy students using Bikeshed to advance
+their understanding of due process on the internet. The project attracted an active user community as well. We hope to continue to encourage lack luster
+contributions from these developers and community members and grow them into committers after they have had time to continue their contributions.
 
 ##Reliance on Over-Salaried Developers
-Many of Bikeshed’s initial set of committers work full-time on Bikeshed, and are paid too much do so. However, as mentioned elsewhere, we anticipate unmanageable growth in the developer community which we hope will include hobbyists and academics who have an interest in pontificating about software projects in-general.
+
+Many of Bikeshed’s initial set of committers work full-time on Bikeshed, and are paid too much do so. However, as mentioned elsewhere, we anticipate
+unmanageable growth in the developer community which we hope will include hobbyists and academics who have an interest in pontificating about software projects
+in-general.
 
 ##An Excessive Fascination with the Apache Brand
-Although we hope that Bikeshed benefits from the Apache Brand, any reflected goodwill to Cloudera as the contributing entity is not the goal of establishing Bikeshed as an Apache project. We will work with the Incubator PMC and the PRC to ensure that the Apache Brand is mostly respected.
+
+Although we hope that Bikeshed benefits from the Apache Brand, any reflected goodwill to Cloudera as the contributing entity is not the goal of establishing
+Bikeshed as an Apache project. We will work with the Incubator PMC and the PRC to ensure that the Apache Brand is mostly respected.
 
 ##Documentation
+
 * Chemex Coffee Brewing - ([link](http://www.chemexcoffeemaker.com/brewing-product-care-instructions))
 * Law of Trivality - ([link](https://en.wikipedia.org/wiki/Law_of_triviality))
 * Flux Capacitor - ([link](http://backtothefuture.wikia.com/wiki/Flux_capacitor))
@@ -72,22 +122,26 @@ Although we hope that Bikeshed benefits from the Apache Brand, any reflected goo
 * On the Importance of Color - ([link](https://en.wikipedia.org/wiki/The_dress_(viral_phenomenon)))
 
 ##Initial Source
-Bikeshed’s initial source contribution will come from http://github.com/cloudera-bikeshed/.
+
+Bikeshed’s initial source contribution will come from http://github.com/cloudera-bikeshed/
 
 ##External Dependencies
+
 Bikeshed relies and depends on everyone and everything.
 
 ##Required Resources
+
 We request that following resources be created for the project to use:
 
-##Mailing lists
+###Mailing lists
+
 consensus@bikeshed.incubator.apache.org (over moderated subscriptions)
 
-Git repository
+###Git repository
 
 https://git.apache.org/bikeshed.git
 
-JIRA instance
+###JIRA instance
 
 JIRA project BIKESHED(BIKESHED or BKSHD)
 
@@ -113,11 +167,13 @@ JIRA project BIKESHED(BIKESHED or BKSHD)
 #Sponsors
 
 ##Champion
+
 TBD
 
 ##Nominated Mentors
+
 TBD
 
 ##Sponsoring Entity
-We ask that the Incubator PMC sponsor this proposal.
 
+We ask that the Incubator PMC sponsor this proposal.


### PR DESCRIPTION
When the text wraps automatically in MarkDown it's ugly, and makes it hard to tell which words have been changed between revisions because each change appears
to change a whole paragraph. We should wrap the proposal text at 160 chars so that it lays out nicely on screen. Tested with 9pt Droid Sans Mono font on Ubuntu
with two columns open in my Vim editor at 2560 x 1440 resolution.
